### PR TITLE
feat: match closest timestamp `ttmlsToCaptionEntries`

### DIFF
--- a/misc/youtube/README.md
+++ b/misc/youtube/README.md
@@ -15,4 +15,8 @@ jq '.captions.playerCaptionsTracklistRenderer.translationLanguages | map({"\(.la
 # Download ttml files
 curl "$(jq -r '.captions.playerCaptionsTracklistRenderer.captionTracks | .[0].baseUrl' misc/youtube/examples/MoH8Fk2K9bc.json)&fmt=ttml" > misc/youtube/examples/MoH8Fk2K9bc-en.ttml
 curl "$(jq -r '.captions.playerCaptionsTracklistRenderer.captionTracks | .[1].baseUrl' misc/youtube/examples/MoH8Fk2K9bc.json)&fmt=ttml" > misc/youtube/examples/MoH8Fk2K9bc-fr-FR.ttml
+
+# Download ttml files via youtube-dl
+video_id="9tnBukLH0Vc"
+youtube-dl -o "misc/youtube/examples/${video_id}.%(ext)s" --skip-download --write-auto-sub --sub-lang=en,fr-FR --sub-format=ttml "https://www.youtube.com/watch?v=${video_id}"
 ```

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -1,3 +1,4 @@
+import { sortBy } from "lodash";
 import { sprintf } from "sprintf-js";
 import { LanguageCode } from "./language";
 import { CaptionConfig, CaptionEntry, VideoMetadata } from "./types";
@@ -97,8 +98,7 @@ export function ttmlsToCaptionEntries(
   const entries1 = ttmlToEntries(ttml1);
   const entries2 = ttmlToEntries(ttml2);
   return entries1.map(({ begin, end, text }) => {
-    // TODO: allow non exact timestamp (it happens for manually added captions)
-    const e2 = entries2.find((e2) => e2.begin === begin);
+    const e2 = sortBy(entries2, (e2) => Math.abs(e2.begin - begin))[0];
     return {
       begin,
       end,


### PR DESCRIPTION
Fixes https://github.com/hi-ogawa/ytsub-v2/issues/57

![Capture d’écran de 2022-02-11 18-14-00](https://user-images.githubusercontent.com/4232207/153565369-7b0c2d0f-15c9-4ca2-9f6d-148fbcb69b41.png)
